### PR TITLE
Fix textarea input in Firefox and fix code alignment everywhere

### DIFF
--- a/styles/Demo.module.scss
+++ b/styles/Demo.module.scss
@@ -12,5 +12,5 @@
 }
 
 .tabStyle {
-  tab-size: 2rem;
+  tab-size: 4;
 }

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -55,7 +55,7 @@ textarea {
   border-radius: var(--border-radius);
   color: var(--color-white);
   padding: 0.5rem 1rem;
-  white-space: nowrap;
+  white-space: pre;
   width: 100%;
 }
 


### PR DESCRIPTION
## Textarea in Firefox
Setting `white-space: nowrap;` on the `<textarea>` causes Firefox to collapse whitespace (turning `\t` into a single space) and strip out all new lines.
Using `pre` instead seems to work as intended across all browsers.

## Code alignment
CSS [`tab-size`](https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size) property should use an integer value to work nicely with fixed-width fonts.

*Before*
![image](https://user-images.githubusercontent.com/2564094/198511535-a8d6faa9-c7b3-439b-8354-622b62455ee7.png)

*After*
![image](https://user-images.githubusercontent.com/2564094/198511450-d429eaad-d3ac-48f2-ac03-aeccb9d54e4c.png)
