### PR TITLE
Fix bundling logic on download page

### DIFF
--- a/components/alert.module.scss
+++ b/components/alert.module.scss
@@ -1,0 +1,63 @@
+.alert {
+  @apply flex rounded-lg border-2 p-2 pb-3;
+
+  a {
+    @apply font-bold underline;
+  }
+
+  &-note {
+    @apply border-cyan-300 bg-cyan-600;
+
+    .icon {
+      @apply text-cyan-100;
+    }
+
+    a {
+      @apply text-cyan-900;
+    }
+  }
+
+  &-success {
+    @apply border-green-300 bg-green-700;
+
+    .icon {
+      @apply text-green-200;
+    }
+
+    a {
+      @apply text-green-200;
+    }
+  }
+
+  &-warning {
+    @apply border-yellow-300 bg-yellow-700;
+
+    .icon {
+      @apply text-yellow-200;
+    }
+
+    a {
+      @apply text-yellow-200;
+    }
+  }
+
+  &-danger {
+    @apply border-red-300 bg-red-700;
+
+    .icon {
+      @apply text-red-200;
+    }
+
+    a {
+      @apply text-red-200;
+    }
+  }
+}
+
+.icon {
+  @apply mr-2 mt-1 w-7;
+}
+
+.message {
+  @apply text-sm leading-4;
+}

--- a/components/alert.tsx
+++ b/components/alert.tsx
@@ -1,0 +1,50 @@
+import {
+  IconDefinition,
+  faCheck,
+  faInfoCircle,
+  faTimesCircle,
+  faTriangleExclamation,
+} from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import React, { ReactNode } from 'react';
+
+import { classList } from '../utilities/cssClasses';
+import styles from './alert.module.scss';
+
+export enum AlertTypes {
+  Note = 'note',
+  Success = 'success',
+  Warning = 'warning',
+  Danger = 'danger',
+}
+
+interface Props {
+  children: ReactNode;
+  className?: string;
+  title?: string;
+  type: AlertTypes;
+}
+
+const AlertIcons: Record<AlertTypes, IconDefinition> = {
+  [AlertTypes.Note]: faInfoCircle,
+  [AlertTypes.Success]: faCheck,
+  [AlertTypes.Warning]: faTriangleExclamation,
+  [AlertTypes.Danger]: faTimesCircle,
+};
+
+export const Alert = ({ children, className, title, type }: Props) => {
+  return (
+    <div
+      className={classList([className, styles.alert, styles[`alert-${type}`]])}
+      role="alert"
+    >
+      <div className={styles.icon}>
+        <FontAwesomeIcon icon={AlertIcons[type]} fixedWidth />
+      </div>
+      <div>
+        {title && <p className="font-bold">{title}</p>}
+        <div className={styles.message}>{children}</div>
+      </div>
+    </div>
+  );
+};

--- a/pages/download.tsx
+++ b/pages/download.tsx
@@ -12,6 +12,7 @@ import {
   useState,
 } from 'react';
 
+import { Alert, AlertTypes } from '../components/alert';
 import { BlurredBackground } from '../components/blurredbackground';
 import SearchableText from '../components/searchable-text';
 import LANG_CATS from '../data/categories.json';
@@ -310,6 +311,19 @@ const Download = () => {
                   <BundlerControls />
                 </section>
               </StickyElement>
+
+              <Alert
+                className="mb-6"
+                type={AlertTypes.Note}
+                title="Behavior Changes"
+              >
+                The design of the download bundle has changed and may be
+                slightly different than what you're expecting. See{' '}
+                <a href="https://github.com/highlightjs/highlightjs.org/pull/10">
+                  PR #10
+                </a>{' '}
+                for more information.
+              </Alert>
 
               <section>
                 {Object.keys(LANG_CATS).map((category) => (

--- a/scripts/build-categories.js
+++ b/scripts/build-categories.js
@@ -12,7 +12,7 @@ if (fs.existsSync(outputCategories)) {
 }
 
 let categories = {
-  'Miscellaneous': [],
+  Miscellaneous: [],
 };
 
 glob.sync(langSrcDir).forEach((filePath) => {

--- a/scripts/build-download-cache.js
+++ b/scripts/build-download-cache.js
@@ -2,9 +2,11 @@ const fs = require('fs');
 const path = require('path');
 const JSZip = require('jszip');
 
-const hljsSrc = path.resolve(__dirname + '/../highlight.js/build/');
 const outputDir = path.resolve(__dirname + '/../data/');
 const outputZip = path.resolve(outputDir + '/bundle-cache.zip');
+
+const hljsSource = path.resolve(__dirname + '/../highlight.js/');
+const buildSource = path.resolve(hljsSource + '/build/');
 
 /**
  * Recursively walk a directory and return all file paths.
@@ -12,19 +14,33 @@ const outputZip = path.resolve(outputDir + '/bundle-cache.zip');
  * @param directory {string} The directory to walk.
  * @param exclude {string[]} Filenames or directory names to exclude.
  * @param filePaths {string[]} The file paths collected so far.
+ * @param options {object}
  *
  * @returns {string[]}
  */
-function walkDir(directory, exclude = [], filePaths = []) {
+function walkDir(directory, exclude = [], filePaths = [], options = {}) {
+  const configuration = {
+    onShouldIgnore: () => true,
+    shouldRecurse: true,
+    ...options,
+  };
+
   fs.readdirSync(directory).forEach((filename) => {
     const filePath = path.join(directory, filename);
 
-    if (exclude.includes(filename)) {
+    if (exclude.includes(filename) && configuration.onShouldIgnore(filePath)) {
       return;
     }
 
     if (fs.statSync(filePath).isDirectory()) {
-      walkDir(filePath, exclude, filePaths);
+      const shouldRecurse =
+        configuration.shouldRecurse instanceof Function
+          ? configuration.shouldRecurse(filePath)
+          : configuration.shouldRecurse;
+
+      if (shouldRecurse) {
+        walkDir(filePath, exclude, filePaths, configuration);
+      }
     } else {
       filePaths.push(filePath);
     }
@@ -37,15 +53,30 @@ if (fs.existsSync(outputZip)) {
   fs.unlinkSync(outputZip);
 }
 
-const files = walkDir(hljsSrc, ['languages']);
+const filesToZip = [];
+walkDir(
+  buildSource,
+  ['highlight.js', 'highlight.min.js', 'languages'],
+  filesToZip,
+);
+
 const archive = new JSZip().folder('highlight');
 
-files.forEach((file) => {
-  const zipPath = file.replace(hljsSrc, '').substring(1);
+filesToZip.forEach((file) => {
+  let zipPath = file.replace(buildSource, '').substring(1);
   const data = fs.readFileSync(file);
 
   archive.file(zipPath, data);
 });
+
+archive.file(
+  'es/highlight.js',
+  fs.readFileSync(path.resolve(buildSource, 'es/highlight.js'), 'utf-8'),
+);
+archive.file(
+  'es/highlight.min.js',
+  fs.readFileSync(path.resolve(buildSource, 'es/highlight.min.js'), 'utf-8'),
+);
 
 archive
   .generateNodeStream({

--- a/scripts/clone-hljs-source.sh
+++ b/scripts/clone-hljs-source.sh
@@ -2,7 +2,7 @@
 set -e
 
 HLJS_REPO="https://github.com/highlightjs/highlight.js.git"
-HLJS_COMMIT="c9e7cbfddceb50b6e71f731c76c4a9c739bb1262"
+HLJS_COMMIT="b7ec4bfafcd8e78a8bbcab353ef9783458a31b89"
 
 clean_data_dir() {
   mkdir -p data/{downloads,snippets}/

--- a/utilities/zip.ts
+++ b/utilities/zip.ts
@@ -6,7 +6,7 @@ export interface ZipFileStructure {
 }
 
 export async function makeZip(contents: ZipFileStructure, baseZipFile = null) {
-  let zip;
+  let zip: JSZip;
 
   if (baseZipFile === null) {
     zip = new JSZip();


### PR DESCRIPTION
> What the fudge is going on with the download page?

Alright, until I get around to completing #2, this PR will serve as the documentation of the expected behavior of bundles.

## The Before: Django website downloads (aka API v1)

A `POST /download` request was treated as a trigger to download a bundle with the specified languages. This endpoint accepted `Content-Type` of type `application/x-www-form-urlencoded` where the keys were languages to be packaged (e.g. `bash=1&cpp=1&javascript=1`).


## The Now: Next.js website downloads (aka API v2)

A `POST /api/download` request triggers a bundle download. This endpoint accepts a `Content-Type` of `application/json` where languages are listed in the `languages` string array.

```
{
  "api": 2,
  "languages": []
}
```

## Were there any BC breaks with the new website?

No. The current `/download` page rewrites any requests matching API v1 expectations to be v2 compatible using the `/api/download` endpoint.

Nothing should have broken with the release of the new website. There have been no complaints since that haven't been addressed, so either no one cares, or it works as expected.

## Now, what's in the download bundle?

Here's where things get a bit tricky. The overall structure of the downloaded ZIP between API v1 and v2 is almost identical, or at least shouldn't have any breaking changes.

Here is a non-exhaustive overview of a downloaded bundle's structure,

```
highlight.zip/
├─ es/
│  ├─ languages/
│  │  ├─ bash.js
│  │  ├─ bash.min.js
│  │  ├─ powershell.js
│  │  ├─ powershell.min.js
│  ├─ core.js
│  ├─ core.min.js
│  ├─ highlight.js
│  ├─ highlight.min.js
├─ languages/
│  ├─ bash.js
│  ├─ bash.min.js
│  ├─ powershell.js
│  ├─ powershell.min.js
├─ styles/
│  ├─ a11y-dark.css
│  ├─ a11y-dark.min.css
│  ├─ ...
├─ DIGESTS.md
├─ highlight.js
├─ highlight.min.js
```

- `DIGESTS.md`: contains the SHA384 hashes of each of the generated files that are included in the bundle
- `es/`
  - `languages/`: contains minified and non-minified versions of grammars in ESM format
  - `highlight.js`: the pure library in an ESM format; non-minified with **NO** grammars concatenated
  - `highlight.min.js`: a minified version of the `highlight.js` in this same folder
- `languages/`: contains both minified and non-minified variants of the grammars in CJS format
- `highlight.js`: the pure library **WITH** the selected grammars concatenated at the end in CJS format; this can be dropped on a web server and it'll work in the browser
- `highlight.min.js`: a minified version of the CJS version of `highlight.js` above

### API v1 vs v2 differences

API v1 appears to have a long-standing bug of bundling up a pure version of `highlight.js` and **ONLY** concatenating grammars in the `highlight.min.js`. If a bundle is requested using V1 of the API, then the `highlight.js` will remain without the concatenated languages at the end for... legacy reasons.

API v2 is _new_ and was just introduced with this Next.js website. I consider it a bug that the unminified `highlight.js` file does not have grammars concatenated at the end. Therefore, this has been changed in the V2 bundles.

---

Fixes #5