### PR TITLE
add missing page description

### DIFF
--- a/layouts/main.tsx
+++ b/layouts/main.tsx
@@ -41,6 +41,11 @@ export const MainLayout = ({ children, description, title }: Props) => {
             <h1 className="text-3xl leading-tight">{title}</h1>
           </div>
         )}
+        {description && (
+          <div className="container mb-4">
+            <p className="mb-8 pl-8 lg:pl-6 text-lg md:text-xl lg:text-2xl">{description}</p>
+          </div>
+        )}
         {children}
       </main>
 


### PR DESCRIPTION
There's no clear description of what the website is for from the beginning of the landing page - the bullet points could relate to a plethora of different types of libraries (I asked ChatGPT!).

Seems like there is a description in the source code but the page template doesn't render it on the page (only included in the metadata).

So here's my attempt at adding it.

Haven't made any attempt at ensuring accessibility, etc.