### PR TITLE
(maint) bump highlight.js to 11.11.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "dedent": "^1.5.3",
         "file-saver": "^2.0.5",
         "gray-matter": "^4.0.2",
-        "highlight.js": "11.10.0",
+        "highlight.js": "11.11.1",
         "indent-textarea": "^4.0.0",
         "jszip": "^3.10.0",
         "lodash.escaperegexp": "^4.1.2",
@@ -1710,9 +1710,9 @@
       }
     },
     "node_modules/highlight.js": {
-      "version": "11.10.0",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.10.0.tgz",
-      "integrity": "sha512-SYVnVFswQER+zu1laSya563s+F8VDGt7o35d4utbamowvUNLLMovFqwCLSocpZTz3MgaSRA1IbqRWZv97dtErQ==",
+      "version": "11.11.1",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
+      "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=12.0.0"

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "dedent": "^1.5.3",
     "file-saver": "^2.0.5",
     "gray-matter": "^4.0.2",
-    "highlight.js": "11.10.0",
+    "highlight.js": "11.11.1",
     "indent-textarea": "^4.0.0",
     "jszip": "^3.10.0",
     "lodash.escaperegexp": "^4.1.2",

--- a/scripts/clone-hljs-source.sh
+++ b/scripts/clone-hljs-source.sh
@@ -2,7 +2,7 @@
 set -e
 
 HLJS_REPO="https://github.com/highlightjs/highlight.js.git"
-HLJS_COMMIT="366a8bd012f33a8f56edfceb9f244fa1f672732f"
+HLJS_COMMIT="08cb242e7d4aee787114eb04cc7ab18314d82f92"
 
 clean_data_dir() {
   mkdir -p data/{downloads,snippets}/


### PR DESCRIPTION
https://github.com/highlightjs/highlight.js/releases/tag/11.11.1

https://github.com/highlightjs/highlight.js/commit/08cb242e7d4aee787114eb04cc7ab18314d82f92


- Closes #22